### PR TITLE
Do not emit the card when editing the course

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# v1.0.0 (Build: 2017092901)
+- Do not emit the card when editing the course (#4).
+- Do not enable the Twitter summary card by default (#4).
+
 # v0.2 (Build: 2017092900)
 - Multi-language content now supported (#2).
 - Improved text shortening (#2).

--- a/lib.php
+++ b/lib.php
@@ -56,6 +56,15 @@ function local_twittercard_before_standard_html_head() {
         if ($enabled && !empty($cm)) {
             $enabled = false;
         }
+        // 3. Do not emit the card if we're editing the course.
+        if ($enabled && $PAGE->user_is_editing()) {
+            $enabled = false;
+        }
+        // 4. Do not emit the card if we're editing the course settings.
+        $courseediturlpath = 'course/edit.php';
+        if ($enabled && (substr($PAGE->url->get_path(), -strlen($courseediturlpath)) === $courseediturlpath)) {
+            $enabled = false;
+        }
 
         if ($enabled) {
             $card = \local_twittercard\helper::create_card($context, $course);

--- a/settings.php
+++ b/settings.php
@@ -38,7 +38,7 @@ if ($hassiteconfig) {
     $name = 'local_twittercard/enabled';
     $title = get_string('enabled', 'local_twittercard');
     $description = get_string('enabled_help', 'local_twittercard');
-    $default = '1';
+    $default = '0';
     $setting = new admin_setting_configcheckbox($name, $title, $description, $default, true, false);
     $settings->add($setting);
 

--- a/version.php
+++ b/version.php
@@ -28,9 +28,9 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_twittercard';
-$plugin->version = 2017092900;
-$plugin->release = '0.2 (Build: 2017092900)';
+$plugin->version = 2017092901;
+$plugin->release = '1.0.0 (Build: 2017092901)';
 $plugin->requires = 2017051500;
-$plugin->maturity = MATURITY_ALPHA;
+$plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;
 $plugin->dependencies = array();


### PR DESCRIPTION
Besides, do not enable the Twitter summary card by default.

Fixes #4