### PR TITLE
Added PHP 7.2 the tested env matrix: Moodle 3.4 supports it.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,23 +16,30 @@ cache:
     - $HOME/.npm
 
 php:
-  - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 env:
   - DB=pgsql  MOODLE_BRANCH=MOODLE_33_STABLE
   - DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE
+  - DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE
   - DB=mysqli MOODLE_BRANCH=master
 
 matrix:
-  exclude:
+  include:
     - php: 5.6
-      env: DB=mysqli MOODLE_BRANCH=master # Moodle 3.4+ requires 7.0.0
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE # Moodle 3.4+ requires 7.0.0
+  exclude:
+    - php: 7.2
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE
+    - php: 7.2
+      env: DB=pgsql  MOODLE_BRANCH=MOODLE_33_STABLE
 
 before_install:
   - phpenv config-rm xdebug.ini
-  - nvm install node
+  - nvm install 8.9
+  - nvm use 8.9
   - cd ../..
   - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^2
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# v1.0.3 (Build: 2017111200)
+- Added PHP 7.2 to the tested env matrix: Moodle 3.4 supports it.
+
 # v1.0.2 (Build: 2017102700)
 - Ready for Moodle 3.4beta (Build: 20171025).
 

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_twittercard';
-$plugin->version = 2017102700;
-$plugin->release = '1.0.2 (Build: 2017102700)';
+$plugin->version = 2017111200;
+$plugin->release = '1.0.3 (Build: 2017111200)';
 $plugin->requires = 2017051500;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
Bumped version to 1.0.3, including a fix in `.travis.yml` (https://github.com/moodlerooms/moodle-plugin-ci/issues/69).
See https://tracker.moodle.org/browse/MDL-60611.
See also https://github.com/travis-ci/travis-ci/issues/7989, pointing to 7.2 RC.