### PR TITLE
Implement Moodle Privacy API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE # Moodle 3.4+ requires 7.0.0
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE # Moodle 3.4+ requires 7.0+
   exclude:
     - php: 7.2
       env: DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# v1.1.0 (Build: 2018040900)
+- Implemented the Moodle Privacy API
+
 # v1.0.4 (Build: 2017121000)
 - Fixed an error when the course summary is not provided.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Copyright (c) 2017 Matteo Scaramuccia <moodle@matteoscaramuccia.com>
 
 # Known issues
 - The first image added into section 0 of a course must be publicly accessible.
-
+- This plugin doesn't automagically log the
+[Twitterbot](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started#url-crawling-caching)
+User-Agent (`"Twitterbot/1.0"`) in ([yet](https://github.com/scara/moodle-local_twittercard/issues/10)) so you need
+to take care of guest access in those courses exposed via a Twitter card.
+More details at [MDL-61586](https://tracker.moodle.org/browse/MDL-61586).
 # TODO
 - Investigate the opportunity to implement more Twitter cards.

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,61 @@
+<?php
+// This file is part of the Twitter Card local plugin for Moodle
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy Subsystem implementation for local_twittercard.
+ *
+ * @package    local_twittercard
+ * @copyright  2018 Matteo Scaramuccia <moodle@matteoscaramuccia.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_twittercard\privacy;
+
+defined('MOODLE_INTERNAL') || die();
+
+// Backward compat.
+interface_exists('\core_privacy\local\metadata\null_provider') || die();
+
+/**
+ * Privacy Subsystem implementation for local_twittercard implementing null_provider.
+ *
+ * @package    local_twittercard
+ * @copyright  2018 Matteo Scaramuccia <moodle@matteoscaramuccia.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements
+    // This plugin does not store any personal user data.
+    \core_privacy\local\metadata\null_provider {
+
+    // 3.4+ runs only on PHP 7.0+ so 'return type declaration' is supported and required,
+    // due to the way the privacy null_provider interface has been implemented in 3.4+.
+    // A polyfill - /privacy/classes/local/legacy_polyfill.php - comes to help here in keeping the same plugin implementation,
+    // regardless the Moodle version, 3.3 vs 3.4+.
+    // Ref.: https://docs.moodle.org/dev/Privacy_API#Difference_between_Moodle_3.3_and_more_recent_versions.
+
+    // This is the trait to be included to actually benefit from the polyfill.
+    use \core_privacy\local\legacy_polyfill;
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function _get_reason() {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/local_twittercard.php
+++ b/lang/en/local_twittercard.php
@@ -30,6 +30,7 @@ defined('MOODLE_INTERNAL') || die();
 $string['enabled'] = 'Enabled';
 $string['enabled_help'] = 'Enable a Twitter summary card for courses.';
 $string['pluginname'] = 'Twitter card';
+$string['privacy:metadata'] = 'The Twitter Card local plugin displays information from the Course, but does not effect or store any data itself.';
 $string['twittercard'] = 'Twitter card';
 $string['twittersite'] = 'Twitter site';
 $string['twittersite_help'] = 'The Twitter @username of website the card should be attributed to.';

--- a/tests/privacy_test.php
+++ b/tests/privacy_test.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of the Twitter Card local plugin for Moodle
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tests for the Privacy API implementation in Twitter summary card.
+ *
+ * @package    local_twittercard
+ * @copyright  2018 Matteo Scaramuccia <moodle@matteoscaramuccia.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Class local_twittercard_privacy_testcase
+ *
+ * @package    local_twittercard
+ * @copyright  2017 Matteo Scaramuccia <moodle@matteoscaramuccia.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class local_twittercard_privacy_testcase extends advanced_testcase {
+    /**
+     * Tests that local_twittercard actually implements the Privacy API null_provider.
+     */
+    public function test_null_provider() {
+        if (!interface_exists('\core_privacy\local\metadata\null_provider')) {
+            $this->markTestSkipped('The Moodle code does not implement the Moodle Privacy API');
+        }
+
+        $this->assertTrue(class_exists('\local_twittercard\privacy\provider'));
+        $this->assertEquals(
+            [ 'core_privacy\local\metadata\null_provider' => 'core_privacy\local\metadata\null_provider' ],
+            class_implements('\local_twittercard\privacy\provider')
+        );
+    }
+}

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_twittercard';
-$plugin->version = 2017121000;
-$plugin->release = '1.0.4 (Build: 2017121000)';
+$plugin->version = 2018040900;
+$plugin->release = '1.1.0 (Build: 2018040900)';
 $plugin->requires = 2017051500;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
Since this plugin today has still a single branch release policy, https://docs.moodle.org/dev/Privacy_API#Difference_between_Moodle_3.3_and_more_recent_versions has made the difference in approaching the Privacy API implementation and the different PHP version support of it.

Se also: https://moodle.org/mod/forum/discuss.php?d=368719