### PR TITLE
Replaced deprecated behat step

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,11 @@
+# v1.1.1 (Build: 2018082500)
+- [Tests] Replaced deprecated Behat step (#18).
+
 # v1.1.0 (Build: 2018040900)
-- Implemented the Moodle Privacy API
+- Implemented the Moodle Privacy API (#15, #17).
 
 # v1.0.4 (Build: 2017121000)
-- Fixed an error when the course summary is not provided.
+- Fixed an error when the course summary is not provided (#13).
 
 # v1.0.3 (Build: 2017111200)
 - Added PHP 7.2 to the tested env matrix: Moodle 3.4 supports it.

--- a/tests/behat/installed.feature
+++ b/tests/behat/installed.feature
@@ -6,7 +6,7 @@ Feature: Installation succeeds
 
   Scenario: Check the Plugins overview for the name of this plugin
     Given I log in as "admin"
-    And I navigate to "Plugins overview" node in "Site administration > Plugins"
+    And I navigate to "Plugins > Plugins overview" in site administration
     Then the following should exist in the "plugins-control-panel" table:
         | Plugin name       |
         | local_twittercard |

--- a/tests/behat/summary_card.feature
+++ b/tests/behat/summary_card.feature
@@ -134,7 +134,7 @@ Feature: A Twitter summary card is added into the page
       | enabled | 1 | local_twittercard |
     And I log in as "admin"
     And I am on "TC Course Guest" course homepage
-    And I navigate to "Enrolment methods" node in "Course administration > Users"
+    And I navigate to "Users > Enrolment methods" in current page administration
     And I click on "Edit" "link" in the "Guest access" "table_row"
     And I set the following fields to these values:
       | Allow guest access | Yes |

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_twittercard';
-$plugin->version = 2018040900;
-$plugin->release = '1.1.0 (Build: 2018040900)';
+$plugin->version = 2018082500;
+$plugin->release = '1.1.1 (Build: 2018082500)';
 $plugin->requires = 2017051500;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 0;


### PR DESCRIPTION
MDL-57281 has deprecated the following behat step in 3.6: I navigate to "ITEM" node in "MAINNODE > PATH"

Fixes #18